### PR TITLE
feat(yarn): add support for yarn berry + artifactory

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,12 +6,18 @@ on:
     branches:
       - main
 
+env:
+  GIT_AUTHOR_NAME: github-actions[bot]
+  GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+  GIT_COMMITTER_NAME: GitHub
+  GIT_COMMITTER_EMAIL: noreply@github.com
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Unit tests
         run: make
@@ -20,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run action
         uses: ./
@@ -45,12 +51,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.16
 
@@ -61,14 +67,14 @@ jobs:
           next=$(svu next --pattern 'v*.*.*')
           echo "current: $(svu current)"
           echo "next:    $next"
-          echo "::set-output name=make::$(if [ "$next" = $(svu current) ]; then echo "0"; else echo "1"; fi)"
-          echo "::set-output name=next::$next"
+          echo "make=$(if [ "$next" = $(svu current) ]; then echo "0"; else echo "1"; fi)" >> $GITHUB_OUTPUT
+          echo "next=$next" >> $GITHUB_OUTPUT
           echo ${next#"v"} > VERSION
 
       - name: Version
         id: version
         if: steps.tag.outputs.make == '1'
-        uses: blackboard-innersource/gh-action-version-cat@v2.0.1
+        uses: blackboard-innersource/gh-action-version-cat@v2
 
       - name: Create GitHub release
         if: steps.tag.outputs.make == '1'
@@ -81,13 +87,14 @@ jobs:
 
       - name: Checkout ${{ steps.version.outputs.version }}
         if: steps.tag.outputs.make == '1'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.version.outputs.version }}
           fetch-depth: 0
 
+      # https://github.com/actions/toolkit/blob/master/docs/action-versioning.md
       - name: Tag and Push v${{ steps.version.outputs.major }}
         if: steps.tag.outputs.make == '1'
         run: |
-          git tag -f v${{ steps.version.outputs.major }}
-          git push -f origin v${{ steps.version.outputs.major }}
+          git tag -fa v${{ steps.version.outputs.major }} -m "Update v${{ steps.version.outputs.major }} tag"
+          git push origin v${{ steps.version.outputs.major }} --force

--- a/setup_yarn.sh
+++ b/setup_yarn.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 require_var() {
   if [ -z "$1" ]; then
     >&2 echo "$2"

--- a/setup_yarn.sh
+++ b/setup_yarn.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+require_var() {
+  if [ -z "$1" ]; then
+    >&2 echo "$2"
+    return 1
+  fi
+  return 0
+}
+
+require_env() {
+  require_var "$2" "Missing env var '$1'"
+}
+
+# Linux base64 wraps while macOS does not
+encode() {
+  local os
+  os=$(uname | tr '[:upper:]' '[:lower:]')
+  if [ "$os" == "linux" ]; then
+    echo -n "$1" | base64 --wrap=0
+  else
+    echo -n "$1" | base64
+  fi
+}
+
+setup_yarn() {
+  if [ "$ARTIFACTORY_SETUP_NPM" == "false" ]; then
+    echo "Skipping npm setup because ARTIFACTORY_SETUP_NPM=$ARTIFACTORY_SETUP_NPM"
+    return 0
+  fi
+
+  require_env "ARTIFACTORY_USERNAME" "$ARTIFACTORY_USERNAME" || return 1
+  require_env "ARTIFACTORY_TOKEN" "$ARTIFACTORY_TOKEN" || return 1
+  require_env "ARTIFACTORY_NPM_REGISTRY" "$ARTIFACTORY_NPM_REGISTRY" || return 1
+
+  local configKey
+  local npmrc
+  local scope
+  local scopes
+  local parts
+  local registry
+  local lines=()
+  local ident
+  local config
+
+  configKey=${ARTIFACTORY_NPM_REGISTRY#"https://"}
+  ident=$(encode "$ARTIFACTORY_USERNAME:$ARTIFACTORY_TOKEN")
+
+  lines+=("npmRegistries:")
+  lines+=("  //${configKey}:")
+  lines+=("    npmAlwaysAuth: true")
+  lines+=("    npmAuthIdent: ${ident}")
+  
+  if [ -n "$ARTIFACTORY_NPM_SCOPES" ]; then
+    # Split ARTIFACTORY_NPM_SCOPES by comma
+    IFS="," read -r -a scopes <<< "$ARTIFACTORY_NPM_SCOPES"
+
+    lines+=("npmScopes:")
+    for scope in "${scopes[@]}"; do
+      lines+=("  $scope:")
+      lines+=("    npmRegistryServer: $ARTIFACTORY_NPM_REGISTRY")
+    done
+  fi
+
+  yarnrc="$HOME/.yarnrc.yml"
+
+  # Join the parts array with newline
+  config=$( IFS=$'\n'; echo "${parts[*]}" )
+
+  echo "$config" > "$yarnrc"
+
+  echo "Wrote to $yarnrc"
+
+  return 0
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  if setup_yarn "$@"; then
+    exit 0
+  fi
+  exit 1
+fi


### PR DESCRIPTION
This PR adds support for Yarn 2 Berry which has deviated from using ~/.npmrc in preference of its own format via ~/.yarnrc.yml. The resulting .yamlrc.yml should look something like:

```
npmRegistries:
  //blackboard.jfrog.io/artifactory/api/npm/fnds-npm/:
    npmAlwaysAuth: true
    npmAuthIdent: ${ARTIFACTORY_IDENT}

npmScopes:
  bb-fnds:
    npmRegistryServer: "https://blackboard.jfrog.io/artifactory/api/npm/fnds-npm"
  lct:
    npmRegistryServer: "https://blackboard.jfrog.io/artifactory/api/npm/fnds-npm"
```