### PR TITLE
fix: entry path for self-hosted runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,5 +3,5 @@ description: Setup package managers to pull packages from Artifactory
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/entry.sh
+    - run: ${GITHUB_ACTION_PATH}/entry.sh
       shell: bash


### PR DESCRIPTION
`${{ github.action_path }}` contains a wrong path if the Action is run in a self-hosted runner, the fix seems to be to use  `${GITHUB_ACTION_PATH}` instead (see https://github.com/actions/runner/issues/716 and https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)